### PR TITLE
Enhance /system_metrics endpoint

### DIFF
--- a/satorineuron/web/satori.py
+++ b/satorineuron/web/satori.py
@@ -1676,8 +1676,13 @@ def systemMetrics():
         'memory': system.getRamDetails(),
         'swap': system.getSwapDetails(),
         'disk': system.getDiskDetails(),
+        'boot_time': system.getBootTime(),
         'uptime': system.getUptime(),
         'version': VERSION,
+        'processor': system.getProcessor(),
+        'processor_count': system.getProcessorCount(),
+        'ram_total_gb': system.getRam(),
+        'ram_available_percent': system.getRamAvailablePercentage(),
     }), 200
 
 

--- a/satorineuron/web/satori.py
+++ b/satorineuron/web/satori.py
@@ -1672,17 +1672,18 @@ def systemMetrics():
     from satorilib.api import system
     return jsonify({
         'hostname': os.uname().nodename,
+        'cpu': system.getProcessor(),
+        'cpu_count': system.getProcessorCount(),
         'cpu_usage_percent': system.getProcessorUsage(),
         'memory': system.getRamDetails(),
+        'memory_total_gb': system.getRam(),
+        'memory_available_percent': system.getRamAvailablePercentage(),
         'swap': system.getSwapDetails(),
         'disk': system.getDiskDetails(),
         'boot_time': system.getBootTime(),
         'uptime': system.getUptime(),
         'version': VERSION,
-        'processor': system.getProcessor(),
-        'processor_count': system.getProcessorCount(),
-        'ram_total_gb': system.getRam(),
-        'ram_available_percent': system.getRamAvailablePercentage(),
+        'timestamp': time.time(),
     }), 200
 
 


### PR DESCRIPTION
This pull request updates the /system_metrics endpoint to provide more comprehensive system information and improve its reliability.

Key changes:

1. Expanded the range of system metrics returned by the endpoint:
   - Added CPU information (processor type and count)
   - Included memory details (total GB and available percentage)
   - Added boot time and system uptime
   - Included a timestamp for when the metrics were collected

2. Utilized the updated functions from the refactored system.py:
   - Now uses getBootTime() and getUptime()
   - Takes advantage of other functions

3. Added the current timestamp to each response for easier tracking and potential debugging

The endpoint now offers a comprehensive overview of the system's current state.
This update relies on the recent changes made to system.py.

Testing needed!

Please review and provide any feedback or suggestions for further improvements.