### PR TITLE
Fix reflected XSS in /unlock by escaping user input in hidden field

### DIFF
--- a/satorineuron/web/satori.py
+++ b/satorineuron/web/satori.py
@@ -323,7 +323,7 @@ def passphrase():
             timeout = min(timeout * 1.618, 60*5)
             return "Wrong passphrase, try again.\n\nIf you're unable to unlock your Neuron remove the setting in the config file."
     next_url = request.args.get('next')
-    return render_template_string(passphrase_html, next=next_url)
+    return render_template('unlock.html', next=next_url)
 
 
 @app.route('/lock/enable', methods=['GET', 'POST'])

--- a/satorineuron/web/templates/unlock.html
+++ b/satorineuron/web/templates/unlock.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Unlock Neuron</title>
+</head>
+<body>
+  <form method="POST" action="/unlock">
+    <label for="passphrase">Passphrase:</label>
+    <input type="password" id="passphrase" name="passphrase" required>
+    <input type="hidden" name="next" value="{{ next }}">
+    <button type="submit">Unlock</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
This patch resolves a reflected Cross-Site Scripting issue in the /unlock route by:

- Moving the HTML to a proper Jinja2 template (unlock.html) to enable autoescaping
- Passing the next query parameter to the template where it is safely rendered

This ensures user input is properly escaped and cannot be used to inject JavaScript into the DOM via crafted links.